### PR TITLE
Add setting for standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "precommit": "yarn lintfix"
   },
   "homepage": "https://9sako6.github.io/commit-stalker/",
-  "eslintConfig": {
-    "extends": "react-app"
+  "standard": {
+    "env": ["jest"]
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
This PR fixes the following errors.

```
yarn run v1.22.10
$ npx standard --fix
standard: Use JavaScript Standard Style (https://standardjs.com)
  /Users/9sako6/ghq/github.com/9sako6/commit-stalker/src/tests/commitRow.test.js:8:1: 'beforeEach' is not defined.
  /Users/9sako6/ghq/github.com/9sako6/commit-stalker/src/tests/commitRow.test.js:14:1: 'afterEach' is not defined.
  /Users/9sako6/ghq/github.com/9sako6/commit-stalker/src/tests/commitRow.test.js:21:1: 'it' is not defined.
  /Users/9sako6/ghq/github.com/9sako6/commit-stalker/src/tests/readme.test.js:8:1: 'beforeEach' is not defined.
  /Users/9sako6/ghq/github.com/9sako6/commit-stalker/src/tests/readme.test.js:14:1: 'afterEach' is not defined.
  /Users/9sako6/ghq/github.com/9sako6/commit-stalker/src/tests/readme.test.js:21:1: 'it' is not defined.
  /Users/9sako6/ghq/github.com/9sako6/commit-stalker/src/tests/readme.test.js:25:3: 'expect' is not defined.
  /Users/9sako6/ghq/github.com/9sako6/commit-stalker/src/tests/readme.test.js:26:3: 'expect' is not defined.
  /Users/9sako6/ghq/github.com/9sako6/commit-stalker/src/tests/readme.test.js:27:3: 'expect' is not defined.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```